### PR TITLE
refactor: update module readme template

### DIFF
--- a/templates/readme-template.md
+++ b/templates/readme-template.md
@@ -1,5 +1,8 @@
-# Module Title
+# <module-name> Hamlet Module 
 
+This is a Hamlet Deploy module.
+
+See docs.hamlet.io for more information.
 ## Description
 <!-- provide a summary of the purpose and use-case for your module -->
 
@@ -13,38 +16,20 @@ list any kind of requirement or dependency for the usage of this module.
 
 ## Usage
 <!--
- Provide an example configuration of the Module in a Solution.
+ Provide a JSONSchema for module configuration.
 
- Ensure all parameters are listed, with "/* optional */" where applicable
+ Generate:
+ hamlet schema -i mock create-schemas -t module -u <module-name>
 -->
 ```json
 {
-  "Modules" : {
-    "<module-id>" : {
-      "Provider" : "",
-      "Name" : "",
-      "Parameters" : {
-
-      }
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "$id": "https://hamlet.io/schema/latest/blueprint/module-alarmslack-schema.json",
+  "definitions": {
+    "<module-name>": {
+      /* */
     }
-  }
-}
-```
-
-
-## Solution
-<!--
-  Provide a Solution-representation of the configuration that this module adds.
-  
-  Values that are dependant on Parameter Values should be identified as:
-  "<id-parameter-value>", "<other-parameter-value" etc.
--->
-
-```json
-{
-	"Solution" : {
-      "Plugins" : {},
-      "Modules" : {}
   }
 }
 ```

--- a/templates/readme-template.md
+++ b/templates/readme-template.md
@@ -2,7 +2,8 @@
 
 This is a Hamlet Deploy module.
 
-See docs.hamlet.io for more information.
+See https://docs.hamlet.io for more information.
+
 ## Description
 <!-- provide a summary of the purpose and use-case for your module -->
 

--- a/templates/readme-template.md
+++ b/templates/readme-template.md
@@ -1,6 +1,6 @@
 # <module-name> Hamlet Module 
 
-This is a Hamlet Deploy module.
+This is a Hamlet Deploy module which provides predefined solutions that can be shared between different products as part of their deployments.
 
 See https://docs.hamlet.io for more information.
 

--- a/templates/readme-template.md
+++ b/templates/readme-template.md
@@ -25,7 +25,7 @@ list any kind of requirement or dependency for the usage of this module.
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
-  "$id": "https://hamlet.io/schema/latest/blueprint/module-alarmslack-schema.json",
+  "$id": "",
   "definitions": {
     "<module-name>": {
       /* */


### PR DESCRIPTION
Updates the Hamlet Deploy modules README.md template with the latest changes.
- add link to docs site
- update usage to reflect using a generated JSONSchema
- cut out the Solution, as this was really just "how to add a module" which should be documented elsewhere and not left to the module authors