### PR TITLE
docs: add template for Extension docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,18 @@ These plugins extend the [hamlet deploy](https://hamlet.io) engine to support di
 
 These are maintained by the hamlet team and are included in the docker distribution
 
+- Shared Provider
+    
+    Provider-independant configuration and definitions.
+
+    - [Extensions](https://github.com/hamlet-io/engine/tree/master/providers/shared/extensions)
+
+
 - [AWS](https://github.com/hamlet-io/engine-plugin-aws)
 
     CloudFormation based Deployments to Amazon Web Services
+
+    - [Extensions](https://github.com/hamlet-io/engine-plugin-aws/tree/master/aws/extensions)
 
 - [Azure](https://github.com/hamlet-io/engine-plugin-azure)
 
@@ -57,11 +66,3 @@ A collection of [Shared Libraries](https://www.jenkins.io/doc/book/pipeline/shar
 - [Hamlet Streams Shared Library](https://github.com/hamlet-io/jenkins-streams-shared-library)
 
     A release process built on top of the functions available in hamlet-deploy
-
-## Extensions
-
-A collection of official Extensions available for use in Hamlet.
-
-- [Shared Provider Extensions](https://github.com/hamlet-io/engine/tree/master/providers/shared/extensions)
-
-- [AWS](https://github.com/hamlet-io/engine-plugin-aws/tree/master/aws/extensions)

--- a/README.md
+++ b/README.md
@@ -57,3 +57,11 @@ A collection of [Shared Libraries](https://www.jenkins.io/doc/book/pipeline/shar
 - [Hamlet Streams Shared Library](https://github.com/hamlet-io/jenkins-streams-shared-library)
 
     A release process built on top of the functions available in hamlet-deploy
+
+## Extensions
+
+A collection of official Extensions available for use in Hamlet.
+
+- [Shared Provider Extensions](https://github.com/hamlet-io/engine/tree/master/providers/shared/extensions)
+
+- [AWS](https://github.com/hamlet-io/engine-plugin-aws/tree/master/aws/extensions)

--- a/templates/readme-template-extensions.md
+++ b/templates/readme-template-extensions.md
@@ -1,0 +1,20 @@
+# <module-name> Hamlet Extension
+
+This is a Hamlet Deploy extension.
+
+See docs.hamlet.io for more information.
+
+## Description
+<!-- provide a summary of the purpose and use-case for your extension -->
+
+## Provider
+<!-- the associated Hamlet Plugin Provider required -->
+
+## Aliases
+<!-- list any aliases that this Extension may be used as -->
+
+## Supported Types
+<!-- List of component types that can be extended -->
+
+## Entrances
+<!-- List of entrances that this extension supports -->

--- a/templates/readme-template-extensions.md
+++ b/templates/readme-template-extensions.md
@@ -1,4 +1,4 @@
-# <module-name> Hamlet Extension
+# <extension-name> Hamlet Extension
 
 This is a Hamlet Deploy extension.
 


### PR DESCRIPTION
A simple README.md template for documenting Extensions.

Includes update to hamlet-library README, linking to the current extensions.